### PR TITLE
[restAPI] Prefer options over params for headers

### DIFF
--- a/src/lib/rest-api.js
+++ b/src/lib/rest-api.js
@@ -28,7 +28,7 @@ function perform(client, config = {}, method = "get", path, params = {}, options
       "Hull-App-Id": config.id,
       "Hull-Access-Token": config.token,
       "Hull-Organization": config.organization,
-      ...(params.headers || {})
+      ...(options.headers || params.headers || {})
     })
     .retry(2, function retryCallback(err, res) {
       const retryCount = this._retries;


### PR DESCRIPTION


## Description of the change

Prefer `options.headers` over `params.headers` in `restAPI` usage.

`params.headers` still works, but putting the headers in `options` keeps them from also being repeated in the request query/body.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None.

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
